### PR TITLE
LPD-13786: Upgrade deprecated Nodejs 12 actions

### DIFF
--- a/.github/workflows/npmpublish.yaml
+++ b/.github/workflows/npmpublish.yaml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://npm.pkg.github.com/
           scope: '@leviy'
       - run: |


### PR DESCRIPTION
v2 uses Node 12 whereas v3 uses node16 which is supported.